### PR TITLE
fix:mock功能使用path严格相等改为router匹配模式

### DIFF
--- a/packages/chameleon-tool/commanders/web/dynamicApiMiddleware.js
+++ b/packages/chameleon-tool/commanders/web/dynamicApiMiddleware.js
@@ -45,7 +45,8 @@ module.exports = function (app, options) {
         if (typeof method === 'string') {
           method = [method];
         }
-        if (~method.indexOf(reqMethod) && item.path === reqPath) {
+        let routeREG = new RegExp('^' + item.path);
+        if (~method.indexOf(reqMethod) && routeREG.test(reqPath)) {
           return item.controller.call(self, req, res, next);
         }
       }


### PR DESCRIPTION
chameleon使用express中间件实现mock模块，但是匹配不是根据路由，而是严格校验path，导致完全失去了router的意义，这里修复为router匹配的模式，可以最大限度实现mock和代理http的灵活性。