### PR TITLE
hotfix: add config autoJoinIfApiPrefixNull for apiprefix

### DIFF
--- a/packages/chameleon-tool/configs/getCommonConfig.js
+++ b/packages/chameleon-tool/configs/getCommonConfig.js
@@ -161,7 +161,7 @@ module.exports = function (options) {
   }
   let devApiPrefix = `http://${config.ip}:${webServerPort}`
   // 兼容旧版api
-  let apiPrefix = options.apiPrefix || devApiPrefix;
+  let apiPrefix = options.apiPrefix ? options.apiPrefix : options.autoJoinIfApiPrefixNull ? devApiPrefix : '';
   // 新版api 优先读取domainMap
   // 浅拷贝不影响config中的domain
   let domain = {};


### PR DESCRIPTION
h5build环境添加autoJoinIfApiPrefixNull配置（默认为false），当apiprefix为空，可以选择默认拼接apiprefix或者不拼接。原框架设定默认情况下，若apiprefix为空，会取服务器ip:port作为origin，这是有问题的